### PR TITLE
Make it possible to force a variant using a request get param

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 setup(
     name='django-variant',
-    version='0.1.1',
+    version='0.1.2',
     description='Django variant testing framework',
     author='Jeremy Sattefield',
     author_email='jsatt@jsatt.com',

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,6 @@ deps =
     six
     mock
     nose
-    django-nose
     jinja2
 
 [testenv]
@@ -18,21 +17,25 @@ setenv =
 [testenv:django15]
 deps =
     django>=1.5, <1.6
+    django-nose<=1.4.2
     {[base]deps}
 
 [testenv:django16]
 deps =
     django>=1.6, <1.7
+    django-nose<=1.4.2
     {[base]deps}
 
 [testenv:django17]
 deps =
     django>=1.7, <1.8
+    django-nose>=1.4.2
     {[base]deps}
 
 [testenv:django18]
 deps =
     django>=1.8, <1.9
+    django-nose>=1.4.2
     {[base]deps}
 
 [testenv:coverage]

--- a/variant/utils.py
+++ b/variant/utils.py
@@ -32,8 +32,13 @@ def get_experiment_variant(request, experiment_name, make_decision=True):
     if experiment:
         cookie_name = get_experiment_cookie_name(experiment_name)
         variant = request.COOKIES.get(cookie_name, None)
+        experiment_variants = experiment.get_variants()
 
-        if not variant or variant not in experiment.get_variants():
+        force_variant = request.GET.get(cookie_name)
+        if force_variant and force_variant in experiment_variants:
+            variant = force_variant
+
+        if not variant or variant not in experiment_variants:
             variant = experiment.choose_variant()
 
     request.variant_experiments[experiment_name] = variant


### PR DESCRIPTION
## Test
- create a variant experiment
- use the cookie name as request GET param `dvc_my_cookie=myvariant`
- the page is forced loaded with that variant
